### PR TITLE
Clean up parameter names in `index.js`

### DIFF
--- a/Sources/JavaScript/index.js
+++ b/Sources/JavaScript/index.js
@@ -52,8 +52,8 @@ const importsObject = {
     log: (address, byteCount) => {
       loggerElement.innerHTML = wasmMemoryAsString(address, byteCount);
     },
-    logInt: (int) => console.log(int),
-    logFloat: (int) => console.log(int),
+    logInt: (x) => console.log(x),
+    logFloat: (x) => console.log(x),
   }
 };
 


### PR DESCRIPTION
This confusingly used `int` parameter name for both `logInt` and `logFloat`.