### PR TITLE
Enable experimental feature Extern.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 
 let embeddedSwiftSettings: [SwiftSetting] = [
     .enableExperimentalFeature("Embedded"), 
+    .enableExperimentalFeature("Extern"),
     .interoperabilityMode(.Cxx),
     .unsafeFlags(["-wmo", "-disable-cmo", "-Xfrontend", "-gnone"])
 ]


### PR DESCRIPTION
Hi,

Thanks for putting this together. Using the latest [main](https://www.swift.org/install/macos/) snapshots for MacOS I did have to add the `.enableExperimentalFeature("Extern"),` to get the project to compile.

Thanks,
Zane