### PR TITLE
Add `.index-build` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
-/.build
+.build
+.index-build
 /Packages
 /*.xcodeproj
 xcuserdata/


### PR DESCRIPTION
This directory is automatically created by SourceKit-LSP when background indexing is enabled and should be ignored.